### PR TITLE
Add user-writeable IN dir

### DIFF
--- a/run
+++ b/run
@@ -21,6 +21,11 @@ useradd $useraddParams "$user"
 chown root:root /home/$user
 chmod 755 /home/$user
 
+indir=/home/$user/IN
+mkdir $indir
+chmod 755 $indir
+chown $user:users $indir
+
 echo "$user:$password" | chpasswd
 
 exec /usr/sbin/sshd -D


### PR DESCRIPTION
Allow users to upload files into special IN directory. User cannot write to own directory because of chroot, as defined in sshd_config. All directories in the chroot must be writeable only by root.
